### PR TITLE
Convert to server-side only

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -26,17 +26,18 @@ logoFile="${mod_id}.png" #optional
 authors="SuperMartijn642" #optional
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''
+displayTest="IGNORE_SERVER_VERSION"
 # Here's another dependency
 [[dependencies.${mod_id}]]
     modId="minecraft"
     mandatory=true
     versionRange="${minecraft_forge_dependency}"
     ordering="NONE"
-    side="BOTH"
+    side="SERVER"
 # Here's another dependency
 [[dependencies.${mod_id}]]
     modId="formations"
     mandatory=true
     versionRange="[${formations_min_version},)"
     ordering="NONE"
-    side="BOTH"
+    side="SERVER"


### PR DESCRIPTION
Prevents the dedicated server from rejecting clients without the mod.

See:
https://docs.minecraftforge.net/en/latest/concepts/sides/
https://docs.minecraftforge.net/en/latest/gettingstarted/modfiles/#modstoml