### PR TITLE
Change item name from 'chain' to 'iron_nugget'

### DIFF
--- a/src/generated/resources/data/formationsoverworld/loot_tables/witch_tower/smithing.json
+++ b/src/generated/resources/data/formationsoverworld/loot_tables/witch_tower/smithing.json
@@ -38,7 +38,7 @@
               "add": false
             }
           ],
-          "name": "minecraft:chain"
+          "name": "minecraft:iron_nugget"
         },
         {
           "type": "minecraft:item",


### PR DESCRIPTION
fixing error: [05:06:32] [Worker-Main-3/ERROR]: Couldn't parse data file 'formationsoverworld:witch_tower/smithing' from 'formationsoverworld:loot_table/witch_tower/smithing.json': DataResult.Error['Unknown registry key in ResourceKey[minecraft:root / minecraft:item]: minecraft:chain': net.minecraft.class_52@6ca50ecd]